### PR TITLE
Change message1

### DIFF
--- a/.github/workflows/app1.yml
+++ b/.github/workflows/app1.yml
@@ -24,6 +24,6 @@ jobs:
 
     - name: Test build
       run: >
-        docker run -v `pwd`:/usr/src/app -w /usr/src/app/app2
+        docker run -v `pwd`:/usr/src/app -w /usr/src/app/app1
         nimlang/nim:$NIM_VER-$OS_VER
         nimble build -y

--- a/app1/src/app1.nim
+++ b/app1/src/app1.nim
@@ -2,4 +2,4 @@ from commonlib as cl import nil
 
 when isMainModule:
   echo("Hello, World!")
-  echo cl.message1()
+  echo cl.message1("app1")

--- a/commonlib/src/commonlib.nim
+++ b/commonlib/src/commonlib.nim
@@ -7,4 +7,4 @@ proc add*(x, y: int): int =
   return x + y
 
 proc message1*(caller: string): string =
-  result = "Hi ", caller, ". commonlib says hello"
+  result = "Hi " & caller & ". commonlib says hello"

--- a/commonlib/src/commonlib.nim
+++ b/commonlib/src/commonlib.nim
@@ -6,5 +6,5 @@ proc add*(x, y: int): int =
   ## Adds two files together.
   return x + y
 
-proc message1*(): string =
-  result = "Hello world from commonlib"
+proc message1*(caller: string): string =
+  result = "Hi ", caller, ". commonlib says hello"


### PR DESCRIPTION
1. Changing function sig in commonlib breaks both apps as expected.  PR can't be merged as expected.

<img width="750" alt="image" src="https://user-images.githubusercontent.com/6628/80854019-e94a3800-8c02-11ea-8e47-57722efbb8bb.png">

2. Fix app1.  Build runs only on app1 and it completes successfully.  I'm unexpectedly able to commit the PR even though app2 is still broken.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/6628/80854215-35e24300-8c04-11ea-9a4c-bd004bc9f65d.png">

What would be nice is if the `Checks` tab showed a list of all the build actions, which ones ran and which ones were skipped.  Ideally, it would have state and say that once app2's build failed, I would need to do something to resolve that before the PR could be merged.